### PR TITLE
MouseControl unit tests

### DIFF
--- a/MouseControl/Program.cs
+++ b/MouseControl/Program.cs
@@ -17,7 +17,7 @@ namespace MouseControl
             //Application.EnableVisualStyles();
             //Application.SetCompatibleTextRenderingDefault(false);
             //Application.Run(new MouseControlForm());
-            MouseControl mouseControl = new MouseControl();
+            MouseControl mouseControl = new MouseControl(args);
             mouseControl.PerformControl();
         }
     }

--- a/SpeechRecognitionHelpers.sln
+++ b/SpeechRecognitionHelpers.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bank", "ConsoleApp1\Bank.cs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BankTests", "BankTests\BankTests.csproj", "{4AF0C2A5-AB5A-4ACE-8191-97A71FA9EDAE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{6C4B26B4-3246-4CAB-9F41-72206EE78F1E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{4AF0C2A5-AB5A-4ACE-8191-97A71FA9EDAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4AF0C2A5-AB5A-4ACE-8191-97A71FA9EDAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4AF0C2A5-AB5A-4ACE-8191-97A71FA9EDAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C4B26B4-3246-4CAB-9F41-72206EE78F1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C4B26B4-3246-4CAB-9F41-72206EE78F1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C4B26B4-3246-4CAB-9F41-72206EE78F1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C4B26B4-3246-4CAB-9F41-72206EE78F1E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UnitTests/MouseControlTests.cs
+++ b/UnitTests/MouseControlTests.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class MouseControlTests
+    {
+        #region Contructor Tests
+
+        [TestMethod]
+        public void Test_constructor_shortArgs_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "5" });
+
+            Assert.AreEqual(2, mc.Arguments.Count);
+            Assert.AreEqual("5", mc.Arguments[0]);
+            Assert.AreEqual("/1", mc.Arguments[1]);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Test_constructor_Args_Fail()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "8", null });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Test_constructor_NullArgs2_Fail()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { null, "9" });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Test_constructor_EmptyArgs_Fail()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "", "9" });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Test_constructor_short_and_EmptyArgs_Fail()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "" });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Test_constructor_short_and_NULLArgs_Fail()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { null });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Test_constructor_short_delay_arg_Fail()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "0", "1" });
+        }
+
+        [TestMethod]
+        public void Test_constructor_EmptyArgs_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[0] { });
+            
+            Assert.AreEqual(2, mc.Arguments.Count);
+            Assert.AreEqual("/0", mc.Arguments[0]);
+            Assert.AreEqual("/1", mc.Arguments[1]);
+        }
+
+        [TestMethod]
+        public void Test_constructor_nullArgs_Pass()
+        {
+            var mc = new MouseControl.MouseControl(null);
+
+            Assert.AreEqual(2, mc.Arguments.Count);
+            Assert.AreEqual("/0", mc.Arguments[0]);
+            Assert.AreEqual("/1", mc.Arguments[1]);
+        }
+
+        [TestMethod]
+        public void Test_constructor_1arg_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "4" });
+
+            Assert.AreEqual(2, mc.Arguments.Count);
+            Assert.AreEqual("4", mc.Arguments[0]);
+            Assert.AreEqual("/1", mc.Arguments[1]);
+        }
+
+        [TestMethod]
+        public void Test_constructor_2args_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/2", "/6" });
+
+            Assert.AreEqual(2, mc.Arguments.Count);
+            Assert.AreEqual("/2", mc.Arguments[0]);
+            Assert.AreEqual("/6", mc.Arguments[1]);
+        }
+
+        [TestMethod]
+        public void Test_constructor_4args_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "10", "20", "30", "40" });
+
+            Assert.AreEqual(4, mc.Arguments.Count);
+            Assert.AreEqual("10", mc.Arguments[0]);
+            Assert.AreEqual("20", mc.Arguments[1]);
+            Assert.AreEqual("30", mc.Arguments[2]);
+            Assert.AreEqual("40", mc.Arguments[3]);
+        }
+
+        #endregion
+
+        #region Perform Control Tests
+
+        [TestMethod]
+        public void Test_PerformControl_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/0" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_missingArgs_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[0] { });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_missingArgs2_Pass()
+        {
+            var mc = new MouseControl.MouseControl(null);
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_missingArgs3_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1" });
+            mc.PerformControl();
+        }      
+
+        [TestMethod]
+        public void Test_PerformControl_right_click_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/right-click" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_upper_left_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/upper-left" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_uper_right_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/upper-right" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_lower_left_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/lower-left" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_right_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/right" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_left_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/left" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_down_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/down" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_up_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/up" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_click_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/click" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_double_click_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/double-click" });
+            mc.PerformControl();
+        }
+
+        [TestMethod]
+        public void Test_PerformControl_stop_Pass()
+        {
+            var mc = new MouseControl.MouseControl(new string[] { "/1", "/stop" });
+            mc.PerformControl();
+        }
+
+        #endregion
+    }
+}

--- a/UnitTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("6c4b26b4-3246-4cab-9f41-72206ee78f1e")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6C4B26B4-3246-4CAB-9F41-72206EE78F1E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>UnitTests</RootNamespace>
+    <AssemblyName>UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MouseControlTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MouseControl\MouseControl.csproj">
+      <Project>{74aa869b-b260-4664-8b4e-9ba17b9fb070}</Project>
+      <Name>MouseControl</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net48" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
- Add UnitTets project (MSTests for .NET Framework)
- Modify MouseControl to take in args from constructor and add more arg validation
- Add MouseControlTests class with control tests and constructor tests

#2  